### PR TITLE
fix: `read_length` returns the wrong size when > 128

### DIFF
--- a/src/fcgi.rs
+++ b/src/fcgi.rs
@@ -137,7 +137,7 @@ fn read_length<T: io::Read>(reader: &mut T) -> Option<io::Result<u32>> {
             Ok(()) => (),
             Err(x) => return Some(Err(x)),
         }
-        Some(Ok((((b1[0] & 0x80) as u32) << 24)
+        Some(Ok((((b1[0] ^ 0x80) as u32) << 24)
                 | ((b2[0] as u32) << 16)
                 | ((b2[1] as u32) << 8)
                 | ((b2[2] as u32))))


### PR DESCRIPTION
It should discard the top bit and keep the 7 following it (so `^ 0x80`), not the other way around (`& 0x80`).